### PR TITLE
Persist wedding password auth across tabs and iOS Safari

### DIFF
--- a/assets/js/wedding.js
+++ b/assets/js/wedding.js
@@ -8,8 +8,29 @@
 	// SHA-256 hash for password verification
 	const actualCorrectHash = 'b370de14e94142d4a108a79df6d0e265a0ba3fa2e10f57c4b3a892b74c9f84aa';
 
+	// Auth lives in localStorage so it is shared across tabs and survives
+	// iOS Safari purging suspended tabs (sessionStorage is per-tab and was
+	// lost in both cases). Storage access can throw in Safari private
+	// browsing, so failures just mean "not authenticated"/"not persisted".
+	// sessionStorage is still read to migrate guests authenticated before
+	// this change.
+	function readAuth() {
+		try {
+			return localStorage.getItem('weddingAuth') || sessionStorage.getItem('weddingAuth');
+		} catch (err) {
+			return null;
+		}
+	}
+
+	function saveAuth(hash) {
+		try {
+			localStorage.setItem('weddingAuth', hash);
+		} catch (err) {}
+	}
+
 	// Check if already authenticated
-	if (sessionStorage.getItem('weddingAuth') === actualCorrectHash) {
+	if (readAuth() === actualCorrectHash) {
+		saveAuth(actualCorrectHash);
 		passwordOverlay.classList.add('hidden');
 		return;
 	}
@@ -38,7 +59,7 @@
 
 		if (enteredHash === actualCorrectHash) {
 			// Correct password
-			sessionStorage.setItem('weddingAuth', actualCorrectHash);
+			saveAuth(actualCorrectHash);
 			passwordOverlay.classList.add('hidden');
 		} else {
 			// Incorrect password


### PR DESCRIPTION
## Summary
Guests were re-prompted for the "lighthouse" password in every new tab, and repeatedly on iOS Safari. The auth hash was kept in `sessionStorage`, which is scoped to a single tab and dropped whenever iOS Safari purges a suspended tab.

- Store the auth hash in `localStorage` instead — shared across tabs and survives tab eviction/browser restart
- Keep a one-time fallback read of the old `sessionStorage` key so guests authenticated before this deploy aren't re-prompted
- Wrap storage access in `try/catch` so Safari private browsing (where storage can throw) still unlocks the page for the current view

## Testing
Verified with a Node harness stubbing DOM + storage, driving the real script: fresh-visit prompt, correct/wrong password, second-tab persistence via localStorage, sessionStorage migration, and throwing-storage (private browsing) fallback — 11/11 pass. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)